### PR TITLE
Build improvements and spinlock replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# build artifacts:
+inpla
+**/build
+
+# linenoise-multiline.patch artifacts:
+src/linenoise/linenoise.c.orig

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,26 @@
 CC      = gcc
-CFLAGS  = -Wall -Winline -O3 -std=gnu99 --param inline-unit-growth=1000 --param max-inline-insns-single=1200
-LDFLAGS = 
-LIBS    = 
+CFLAGS_COMMON = -Wall -Winline -std=gnu99 --param inline-unit-growth=1000 --param max-inline-insns-single=1200
+LIBS    =
 INCLUDE = -I ./src
 SRC_DIR = ./src
 OBJ_DIR = ./build
 TARGET  = inpla
 OBJS    = $(OBJ_DIR)/inpla.tab.c $(OBJ_DIR)/ast.o $(OBJ_DIR)/id_table.o $(OBJ_DIR)/name_table.o $(OBJ_DIR)/linenoise.o
 DEPS	= $(SRC_DIR)/config.h
+
+ifeq ($(DEBUG),thread)
+CFLAGS  = $(CFLAGS_COMMON) -O1 -g -fsanitize=thread
+LDFLAGS = -fsanitize=thread
+
+else ifeq ($(DEBUG),address)
+CFLAGS  = $(CFLAGS_COMMON) -O1 -g -fsanitize=address -fsanitize=undefined
+LDFLAGS = -fsanitize=address
+
+else
+CFLAGS  = $(CFLAGS_COMMON) -O3
+LDFLAGS =
+
+endif
 
 #MYOPTION = -DHAND_FIB -DHAND_FIB_INT  -DHAND_I_CONS -DHAND_IS_CONS -DHAND_Apnd_CONS -DHAND_Part_CONS -DHAND_Split_CONS -DHAND_MergeCC_CONS -DHAND_B_CONS -DHAND_DUP_S -DHAND_ADD_S -DHAND_ACK_S
 #MYOPTION = -DHAND_Split_CONS -DHAND_MergeCC_CONS

--- a/Makefile
+++ b/Makefile
@@ -15,20 +15,19 @@ DEPS	= $(SRC_DIR)/config.h
 
 .PHONY: all
 
-all: $(OBJ_DIR) $(TARGET) 
+all: $(OBJ_DIR) $(TARGET)
 
 $(TARGET): $(OBJS) $(LIBS) $(DEPS)
-	$(CC) $(CFLAGS) $(INCLUDE) $(MYOPTION) -o $@ $(OBJS) $(LDFLAGS) 
+	$(CC) $(CFLAGS) $(INCLUDE) $(MYOPTION) -o $@ $(OBJS) $(LDFLAGS)
 
 $(OBJ_DIR)/linenoise.o: $(SRC_DIR)/linenoise/linenoise.c
 	@if [ ! -f $(SRC_DIR)/linenoise/linenoise.c.orig ]; then \
 		patch --backup --version-control=simple --suffix=.orig $(SRC_DIR)/linenoise/linenoise.c $(SRC_DIR)/linenoise/linenoise-multiline.patch; \
 	fi
-	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $< 
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 
-
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c 
-	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $< 
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
+	$(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
 
 $(OBJ_DIR)/inpla.tab.c : $(SRC_DIR)/inpla.y $(OBJ_DIR)/lex.yy.c
 	bison -o $@ $<
@@ -41,13 +40,12 @@ $(OBJ_DIR):
 		echo ";; mkdir $(OBJ_DIR)"; mkdir $(OBJ_DIR); \
 	fi
 
+thread: $(OBJ_DIR) $(OBJS) $(LIBS)
+	$(CC) $(CFLAGS) $(INCLUDE) $(MYOPTION) -DTHREAD -o $(TARGET) $(OBJS) $(LDFLAGS) -lpthread
+
 clean:
 	rm -f $(TARGET)* $(OBJ_DIR)/* *stackdump* *core*
 	@if [ -f $(SRC_DIR)/linenoise/linenoise.c.orig ]; then \
 		echo "mv -f $(SRC_DIR)/linenoise/linenoise.c.orig $(SRC_DIR)/linenoise/linenoise.c"; \
 		mv -f $(SRC_DIR)/linenoise/linenoise.c.orig $(SRC_DIR)/linenoise/linenoise.c; \
 	fi
-
-
-thread: $(OBJS) $(LIBS)
-	$(CC) $(CFLAGS) $(INCLUDE) $(MYOPTION) -DTHREAD -o $(TARGET) $(OBJS) $(LDFLAGS) -lpthread

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Inpla is a multi-threaded parallel interpreter of interaction nets. Once you wri
     ```
      To get the single-thread version again, use `make clean; make`.
 
+> Debug builds are available with `DEBUG=thread` (ThreadSanitizer) and `DEBUG=address` (AddressSanitizer + UBSan):
+
 ## How to Execute
 
 ### Interactive mode (single-thread version)

--- a/src/cas_spinlock.h
+++ b/src/cas_spinlock.h
@@ -1,34 +1,30 @@
+#ifndef _CAS_SPINLOCK_
+#define _CAS_SPINLOCK_
+
 //#define CAS_LOCK_USLEEP 4
 #define CAS_LOCK_USLEEP 200
 
-
-
-#define USE_UNLIKELY
-#ifdef USE_UNLIKELY
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include "unlikely.h"
-static inline void lock(volatile int *aexclusion) {
-  if (likely(__sync_lock_test_and_set(aexclusion, 1) == 0)) {
-      return; 
-  }
 
-  while (__sync_lock_test_and_set(aexclusion, 1)) {
-    while (*aexclusion) {
-      usleep(CAS_LOCK_USLEEP);
-    }
-  }
+static inline void lock(pthread_spinlock_t *__lock) {
+ int ret = pthread_spin_lock(__lock);
+
+ if(unlikely(ret)) {
+   printf("Error: pthread_spin_lock() == %d\n", ret);
+   abort();
+ }
 }
 
-#else
+static inline void unlock(pthread_spinlock_t *__lock) {
+ int ret = pthread_spin_unlock(__lock);
 
-static inline void lock(volatile int *aexclusion) {
-  while (__sync_lock_test_and_set(aexclusion, 1))
-    while (*aexclusion)
-      usleep(CAS_LOCK_USLEEP);
+ if(unlikely(ret)) {
+   printf("Error: pthread_spin_unlock() == %d\n", ret);
+   abort();
+ }
 }
 
 #endif
-
-
-static inline void unlock(volatile int *aexclusion) {
-  __sync_lock_release(aexclusion); 
-}

--- a/src/inpla.y
+++ b/src/inpla.y
@@ -2396,23 +2396,16 @@ void puts_memory_stat(void) {
 static pthread_cond_t EQStack_not_empty = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t Sleep_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t AllSleep_lock = PTHREAD_MUTEX_INITIALIZER;
-#endif
-
-
 
 // GlobalEQStack for execution with threads
-#ifdef THREAD
 typedef struct {
   EQ *stack;
   int nextPtr;
   int size;
-  volatile int lock;  // for lightweight spin lock
+  pthread_spinlock_t lock;
 } EQStack;
 static EQStack GlobalEQS;
-#endif
 
-
-#ifdef THREAD
 void GlobalEQStack_Init(int size) {
  GlobalEQS.nextPtr = -1;
  GlobalEQS.stack = malloc(sizeof(EQ)*size);
@@ -2421,13 +2414,25 @@ void GlobalEQStack_Init(int size) {
     printf("Malloc error\n");
     exit(-1);
   }
+
   // for cas_lock
- GlobalEQS.lock = 0;
+ int ret = pthread_spin_init(&GlobalEQS.lock, PTHREAD_PROCESS_PRIVATE);
+ if (ret) {
+    printf("Spin lock init err:%d\n", ret);
+
+    free(GlobalEQS.stack);
+    exit(-1);
+ }
 }
-#endif
 
+void GlobalEQStack_Deinit() {
+ if (!GlobalEQS.stack)
+  return;
 
-#ifdef THREAD
+ free(GlobalEQS.stack);
+ pthread_spin_destroy(&GlobalEQS.lock);
+}
+
 void GlobalEQStack_Push(VALUE l, VALUE r) {
 
   lock(&GlobalEQS.lock);
@@ -2452,7 +2457,6 @@ void GlobalEQStack_Push(VALUE l, VALUE r) {
     pthread_cond_signal(&EQStack_not_empty);
     pthread_mutex_unlock(&Sleep_lock);
   }
-
 }
 #endif
 


### PR DESCRIPTION
This PR contains the following changes:

- Replace custom CAS-based spinlock with `pthread_spinlock_t`.
  > 1. The previous custom implementation based on CAS had data race issues detected by ThreadSanitizer. 
  > Switching to `pthread_spinlock_t` eliminates these races.
  > 2. Additionally, `pthread_spinlock_t` implementations typically include optimizations that were missing in the custom spinlock. glibc example: https://elixir.bootlin.com/glibc/glibc-2.43/source/nptl/pthread_spin_lock.c#L52)
- Add `DEBUG` build flag supporting `DEBUG=thread` (ThreadSanitizer) and `DEBUG=address` (AddressSanitizer + UBSan) presets with `-O1` `-g`.
- Fix `make thread` target missing `$(OBJ_DIR)` dependency causing build failure on clean tree.
- Add `.gitignore` covering build artifacts and linenoise patch artifacts.